### PR TITLE
Use get_parent instead of _parent_header

### DIFF
--- a/src/sos_notebook/kernel.py
+++ b/src/sos_notebook/kernel.py
@@ -18,6 +18,7 @@ import pandas as pd
 import pkg_resources
 from ipykernel.ipkernel import IPythonKernel
 from ipykernel.comm.manager import CommManager
+from ipykernel._version import version_info as ipykernel_version_info
 
 from IPython.utils.tokenutil import line_at_cursor, token_at_cursor
 from jupyter_client import manager
@@ -1331,7 +1332,10 @@ class SoS_Kernel(IPythonKernel):
         # use the msg_id of the sos kernel for the subkernel to make sure that the messages sent
         # from the subkernel has the correct msg_id in parent_header so that they can be
         # displayed directly in the notebook (without using self._parent_header
-        msg['msg_id'] = self._parent_header['header']['msg_id']
+        if ipykernel_version_info[0] >= 6:
+            msg['msg_id'] = self.get_parent()['header']['msg_id']
+        else:
+            msg['msg_id'] = self._parent_header['header']['msg_id']
         msg['header']['msg_id'] = msg['msg_id']
         self.KC.shell_channel.send(msg)
 


### PR DESCRIPTION
_parent_header is depreciated with ipykernel 6
https://github.com/ipython/ipykernel/blob/97c36b5110de5aa49b6b045f2b36cd4428c5feae/ipykernel/kernelbase.py#L140-L146
I tested with ipykernel 6 and lower versions for compatibility 