### PR TITLE
Replaced collection imports with collections.abc (Issue #336)

### DIFF
--- a/src/sos_notebook/magics.py
+++ b/src/sos_notebook/magics.py
@@ -8,7 +8,8 @@ import shlex
 import builtins
 import subprocess
 import sys
-from collections import Sized, OrderedDict, Sequence
+from collections.abc import Sized, Sequence
+from collections import OrderedDict
 from io import StringIO
 from types import ModuleType
 


### PR DESCRIPTION
Issue #336 

Replaced collections imports with collections.abc  for Sized, Sequence otherwise causes ImportError
Changed in Python 3.3. 
Old method stops working in python 3.10 

Please Note:  collections.abc does not work for OrderedDict still have to use collections I think this need to be raised as a python issue. 

 https://stackoverflow.com/a/70195883