### PR TITLE
Add jupyter_contrib_core as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
         'jinja2',
         'notebook>=5.0.0',
         'tabulate',
+        'jupyter_contrib_core',
         # 'markdown',
         'pandas',
         'numpy',


### PR DESCRIPTION
This module is only used during installation but is still needed anyway.